### PR TITLE
Undefined name: import matplotlib as plt

### DIFF
--- a/dataset/datasets.py
+++ b/dataset/datasets.py
@@ -1,5 +1,6 @@
 import os
 import os.path as osp
+import matplotlib as plt
 import numpy as np
 import random
 import collections


### PR DESCRIPTION
flake8 testing of https://github.com/speedinghzl/CCNet on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./evaluate.py:158:33: F821 undefined name 'predict_whole_img'
            flip_scaled_probs = predict_whole_img(net, scale_image[:,:,:,::-1].copy(), tile_size, recurrence)
                                ^
./dataset/datasets.py:299:13: F821 undefined name 'plt'
            plt.imshow(img)
            ^
./dataset/datasets.py:300:13: F821 undefined name 'plt'
            plt.show()
            ^
3     F821 undefined name 'plt'
3
```

On the other _undefined_name_, I would guess that should be __predict_whole()__ instead of __predict_whole_img()__.